### PR TITLE
Fix for ambient_general via fgd to restore ambient sounds 

### DIFF
--- a/source/maps/fgd/hl-nzp.fgd
+++ b/source/maps/fgd/hl-nzp.fgd
@@ -1364,10 +1364,20 @@
 	]
 ]
 
-@PointClass = ambient_general : "Universal Ambient Sound"
-[
+@PointClass base(Targetname, Soundplaying) = ambient_generic : "Universal Ambient Sound"
+[	
+	spawnflags(flags) = 
+	[
+		0: "Medium radius"
+		1: "Everywhere"
+		2: "Small (Idle)"
+		4: "Medium (static)"
+		8: "Large (normal)"
+		16: "Start Silent"
+		32: "Not looping"
+	]
 	volume(integer) : "Volume" : 1
-	noise(string) : "Ambient Sound"
+	message(string) : "Ambient Sound"
 ]
 
 @PointClass base(Targetname, Soundplaying) = ambient_bgm : "Back Ground Music"

--- a/source/maps/fgd/tb-nzp.fgd
+++ b/source/maps/fgd/tb-nzp.fgd
@@ -1364,10 +1364,20 @@
 	]
 ]
 
-@PointClass = ambient_general : "Universal Ambient Sound"
-[
+@PointClass base(Targetname, Soundplaying) = ambient_generic : "Universal Ambient Sound"
+[	
+	spawnflags(flags) = 
+	[
+		0: "Medium radius"
+		1: "Everywhere"
+		2: "Small (Idle)"
+		4: "Medium (static)"
+		8: "Large (normal)"
+		16: "Start Silent"
+		32: "Not looping"
+	]
 	volume(integer) : "Volume" : 1
-	noise(string) : "Ambient Sound"
+	message(string) : "Ambient Sound"
 ]
 
 @PointClass base(Targetname, Soundplaying) = ambient_bgm : "Back Ground Music"


### PR DESCRIPTION
The entity `ambient_general` did not play any sound, so I read the qc code for it and it was missing. I managed to do quick patch by rewriting the fgd files to use `ambient_generic` instead, with all the spawnflags for it correctly named.