### PR TITLE
TEST: Assert MDL skin width is multiple of four

### DIFF
--- a/testing/mdl_validator.sh
+++ b/testing/mdl_validator.sh
@@ -77,6 +77,10 @@ function validate_mdl_header()
         echo "    - ERROR: Skin width is zero!"
         should_fail="1"
     fi
+    if (( skin_width % 4 != 0 )); then
+        echo "    - ERROR: Skin width is not multiple of four!"
+        should_fail="1"
+    fi
 
     # Skin Height
     local skin_height=$(read_int_in_file_at_ofs "${mdl_file}" "${MDL_SKINHEIGHT_OFS}")


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `MAPS`: Maps
* `GFX`: HUD/Menu/etc. graphics
* `SOUNDS`: Sounds
* `WAD`: Map textures/map wads
* `CFG`: Configuration files

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Doing some digging trying to produce failure for the bad mesh in nzp-team/nzportable#1194 I found some additional safe guards that some early Quake engines have with the skin width required to be a multiple of four. While height can be arbitrarily set this way (and we do so on quite a few models, this probably should be revisited) width cannot behave this way. So I added a check to safeguard against this which fails on our broken model.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
```
[INFO]: Verifying MDL model [./common/broken_mesh.mdl]..
  + MAGIC: [IDPO]
  + VERSION: [6]
  + SKIN WIDTH: [127]
    - ERROR: Skin width is not multiple of four!
  + SKIN HEIGHT: [59]
  + VERTICES: [113]
  + TRIANGLES: [174]
  + FRAMES: [47]
  - ERROR: Invalid header for MDL [./common/broken_mesh.mdl]!
[ERROR]: FAILED to validate [1] MDL models!
```
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
