### PR TITLE
`MAPS` Fix missing `targetname` on `window_1`

### DIFF
--- a/source/maps/template.map
+++ b/source/maps/template.map
@@ -1,11 +1,10 @@
-// Game: Nazi Zombies: Portable
+// Game: Nazi Zombies Portable
 // Format: Valve
 // entity 0
 {
 "mapversion" "220"
 "wad" "../../textures/wad/zhlt.wad;../../textures/wad/Example_02.wad"
 "classname" "worldspawn"
-"_tb_layer_hidden" "1"
 // brush 0
 {
 ( -144 -64 -16 ) ( -144 -63 -16 ) ( -144 -64 -15 ) null [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
@@ -285,6 +284,7 @@
 "spawnflags" "0"
 "origin" "124 76 80"
 "angle" "180"
+"targetname" "window_1"
 }
 // entity 8
 {
@@ -389,6 +389,7 @@
 "_tb_name" "Zone Layer"
 "_tb_id" "1"
 "_tb_layer_sort_index" "0"
+"_tb_layer_hidden" "1"
 }
 // entity 16
 {


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `MAPS`: Maps
* `GFX`: HUD/Menu/etc. graphics
* `SOUNDS`: Sounds
* `WAD`: Map textures/map wads
* `CFG`: Configuration files

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds the missing `targetname` field to `window_1` to fix zombie pathing

### Visual Sample
---
<img width="912" height="848" alt="image" src="https://github.com/user-attachments/assets/9ab50f2a-e8b2-4d9c-a87a-38dede046198" />

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
