### PR TITLE
NX/VITA: Reassign +use for holding LEFTFACE

### DIFF
--- a/nx/nzportable/nzp/config.cfg
+++ b/nx/nzportable/nzp/config.cfg
@@ -1,6 +1,6 @@
 unbindall
 bind "ESCAPE" "togglemenu"
-bind "UPARROW" "+use"
+bindhold "LEFTFACE" "+use"
 bind "RIGHTARROW" "impulse 22"
 bind "LTHUMB" "impulse 23"
 bind "RTHUMB" "+knife"

--- a/vita/data/nzp/nzp/config.cfg
+++ b/vita/data/nzp/nzp/config.cfg
@@ -1,7 +1,6 @@
 unbindall
 bind "ESCAPE" "togglemenu"
-
-bind "UPARROW" "+use"
+bindhold "LEFTFACE" "+use"
 bind "LEFTFACE" "+reload"
 bind "DOWNARROW" "impulse 23"
 bind "RIGHTFACE" "impulse 30"


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `MAPS`: Maps
* `GFX`: HUD/Menu/etc. graphics
* `SOUNDS`: Sounds
* `WAD`: Map textures/map wads
* `CFG`: Configuration files

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Makes +use on NX/VITA holding LEFTFACE to match CoD.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
